### PR TITLE
Update moonPhase.groovy w/graphic overlay in SVG

### DIFF
--- a/moonPhase.groovy
+++ b/moonPhase.groovy
@@ -192,29 +192,18 @@ void getPhase(Long cDate = now()) {
     
     // Generate SVG output from template
     String svgString = """
-        <svg width="150" height="150">
-        <defs>
-        <mask id="arc">
-        <path d="M75,5 Arx1,70 180 0 sf1 75,145 Arx2,70 180 0 sf2 75,5 z" fill="#fff" style="filter:blur(3px)"/>
-        </mask>
-        <filter id="surface" >
-        <feTurbulence type="turbulence" baseFrequency="0.025" numOctaves="4"/>
-        <feDiffuseLighting>
-        <feDistantLight elevation="20"/>
-        </feDiffuseLighting>
-        <feGaussianBlur stdDeviation="1.2"/>
-        <feComposite operator="in" in2="SourceGraphic"/>
-        </filter>
-        <radialGradient id="shadow">
-        <stop offset="10%" stop-color="#0009"/>
-        <stop offset="90%" stop-color="#000e"/>
-        </radialGradient>
-        </defs>
-        <g style="filter:blur(1.2px)">
-        <circle cx="75" cy="75" r="70.3" filter="url(#surface)"/> // lunar surface
-        <circle cx="75" cy="75" r="70" mask="url(#arc)" fill="url(#shadow)"/> // lunar penumbra
-        </g>
-        </svg>
+    <svg width="150" height="150"><defs><mask id="arc">
+    <path d="M75,5 Arx1,70 180 0 sf1 75,145 Arx2,70 180 0 sf2 75,5 z" fill="#fff" style="filter:blur(3px)"/>
+    </mask><filter id="surface">
+    <feImage x="4" width="95%" href="https://raw.githubusercontent.com/LibraSun/Hubitat/main/Resources/lunar_surface.png"/>
+    <feComposite operator="in" in2="SourceGraphic"/></filter>
+    <radialGradient id="shadow">
+    <stop offset="10%" stop-color="#0007"/>
+    <stop offset="90%" stop-color="#000d"/>
+    </radialGradient></defs>
+    <circle cx="75" cy="75" r="70.3" filter="url(#surface)"/>
+    <circle cx="75" cy="75" r="70" mask="url(#arc)" fill="url(#shadow)"/>
+    </svg>
         """
     Double rx1 = 70.0 // right limn radius
     Integer sf1 = 1 // right limn sweep flag concave )


### PR DESCRIPTION
1. Leveraging 'feImage' filter to import (non-copyrighted) image of moon - appears as expected in Chrome/Windows (check others!)
2. Adjusted position and scaling to center within image
3. Tested working on Local and Cloud dashboard tiles (web & app)
4. Removed earlier texture-generating filter(s) for lean code