### PR TITLE
Force headers in readExtFile to be an empty Map

### DIFF
--- a/hubInfoV3.groovy
+++ b/hubInfoV3.groovy
@@ -1475,7 +1475,7 @@ String readExtFile(fName){
         contentType: "text/html",
         textParser: true,
         headers: [
-				
+            :
             ]        
     ]
 


### PR DESCRIPTION
This addresses #26 by initializing `headers` as an empty Map. As an alternative, the entire `headers` element could be removed since it is empty.