### PR TITLE
fix issue related to script-level variable bindings

### DIFF
--- a/airthings/airThingsCntrl.groovy
+++ b/airthings/airThingsCntrl.groovy
@@ -83,10 +83,7 @@ def mainPage(){
                     apiGet("devices")
                 }
                 if(state.temp_token != null) {
-                    if(state.temp_token.size() > 50)
-                        eos = 50
-                    else 
-                        eos = state.temp_token.size()
+                    def eos = state.temp_token.size() > 50 ? 50 : state.temp_token.size()
                     paragraph "<b>Token:</b> ${state.temp_token.toString().substring(0,eos)}. . . . ."
                     paragraph "<b>Expires:</b> ${state?.tokenExpiresDisp}"
                 }
@@ -112,7 +109,7 @@ def mainPage(){
                         state.numberDevices+=2
                 }*/
                 if (state?.numberDevices > 0){
-                    chdList = []
+                    def chdList = []
                     getChildDevices().each{
                         chdList.add("$it")
                     }
@@ -146,7 +143,7 @@ def mainPage(){
 //Begin App Authorization 
 
 void getAuth(command){
-    bodyMap = [grant_type:"client_credentials",client_id:"$userName", client_secret:"$pwd","scope": ["read:device:current_values"]]
+    def bodyMap = [grant_type:"client_credentials",client_id:"$userName", client_secret:"$pwd","scope": ["read:device:current_values"]]
 
     def bodyText = JsonOutput.toJson(bodyMap)
 	Map requestParams =
@@ -208,8 +205,8 @@ def getApi(resp, data){
         if(resp.getStatus() == 200 || resp.getStatus() == 207){
             if(resp.data){
                 if(data.cmd == "devices"){
-                    jsonData = (HashMap) resp.json
-                    numDev = 0
+                    def jsonData = (HashMap) resp.json
+                    def numDev = 0
                     jsonData.devices.each{
                         if(debugEnabled) log.debug "${it.id}, ${it.deviceType}, ${it.segment.name}"
                         createChildDev(it.id, it.deviceType, it.segment.name, it.location.name)
@@ -217,12 +214,12 @@ def getApi(resp, data){
                     }
                     state.numberDevices = numDev
                 } else if(data.cmd.contains("latest-samples")) {
-                    start = data.cmd.indexOf('/')+1
-                    end = data.cmd.indexOf('/',start)
-                    devId = data.cmd.substring(start,end)
-                    cd = getChildDevice("${app.id}-$devId")
-                    jsonData = (HashMap) resp.json
-                    cd.dataRefresh(jsonData)                    
+                    def start = data.cmd.indexOf('/')+1
+                    def end = data.cmd.indexOf('/',start)
+                    def devId = data.cmd.substring(start,end)
+                    def cd = getChildDevice("${app.id}-$devId")
+                    def jsonData = (HashMap) resp.json
+                    cd.dataRefresh(jsonData)
                 } else {
                     log.error "Unhandled Command: '${data.cmd}'"
                 }
@@ -239,6 +236,7 @@ def getApi(resp, data){
 // End API
 
 void createChildDev(devId, devType, devName, devLoc){
+    def cd
     if(!this.getChildDevice("${app.id}-$devId"))
         cd = addChildDevice("thebearmay", "Air Things Device", "${app.id}-$devId", [name: "${devName}", isComponent: true, deviceId:"$devId", label:"$devName"])
     else
@@ -275,7 +273,7 @@ void intialize() {
 }
 
 void uninstalled(){
-    chdList = getChildDevices()
+    def chdList = getChildDevices()
     chdList.each{
         deleteChildDevice(it.getDeviceNetworkId())
     }

--- a/airthings/airthingsDevice.groovy
+++ b/airthings/airthingsDevice.groovy
@@ -106,7 +106,6 @@ preferences {
 //        input("username","string", title:"Hub Security Username")
 //        input("password","string", title:"Hub Security Password")
 //    }
-    fileList = []
     fileList = listFiles()
 
     input("tileTemplate", "enum", title:"Template for generating HTML for dashboard tile", options:fileList, defaultValue:"--No Selection--", submitOnChange:true)
@@ -340,7 +339,7 @@ List<String> listFiles(){
             }
             fileList.add("--No Selection--")
         }
-        if(debugEnabled) log.debug fileList.sort()
+        //if(debugEnabled) log.debug fileList.sort()
         return fileList.sort()
     } catch (e) {
         log.error e
@@ -352,4 +351,4 @@ void logsOff(){
      device.updateSetting("debugEnabled",[value:"false",type:"bool"])
 }
 
-@Field sdfList = ["yyyy-MM-dd","yyyy-MM-dd HH:mm","yyyy-MM-dd h:mma","yyyy-MM-dd HH:mm:ss","ddMMMyyyy HH:mm","ddMMMyyyy HH:mm:ss","ddMMMyyyy hh:mma", "dd/MM/yyyy HH:mm:ss", "MM/dd/yyyy HH:mm:ss", "dd/MM/yyyy hh:mma", "MM/dd/yyyy hh:mma", "MM/dd HH:mm", "HH:mm", "H:mm","h:mma", "HH:mm:ss", "Milliseconds"]
+@Field static final sdfList = ["yyyy-MM-dd","yyyy-MM-dd HH:mm","yyyy-MM-dd h:mma","yyyy-MM-dd HH:mm:ss","ddMMMyyyy HH:mm","ddMMMyyyy HH:mm:ss","ddMMMyyyy hh:mma", "dd/MM/yyyy HH:mm:ss", "MM/dd/yyyy HH:mm:ss", "dd/MM/yyyy hh:mma", "MM/dd/yyyy hh:mma", "MM/dd HH:mm", "HH:mm", "H:mm","h:mma", "HH:mm:ss", "Milliseconds"]

--- a/airthings/airthingsDevice.groovy
+++ b/airthings/airthingsDevice.groovy
@@ -88,7 +88,6 @@ metadata {
         attribute "html", "string"
     	attribute "relayDeviceType", "string"    //GFA
         attribute "rssi", "number"
-//        attribute "relayDeviceType", "string"
 
 //        command "test",[[name:"val*", type:"NUMBER", description:"pm25 Value"]]
     }
@@ -160,87 +159,78 @@ void dataRefresh(retData){
     retData.data.each{
         if(debugEnabled) log.debug "Each:${it.key}"
         def unit = ""
-        switch (it.key){
+        def attr = it.key
+        def value = it.value
+        switch (attr){
             case("temp"):
+            	attr = "temperature"
                 unit="°C"
                 if(useFahrenheit){
-                    it.value = celsiusToFahrenheit(it.value)
+                    value = celsiusToFahrenheit(value)
                     unit = "°F"
                 }
-                updateAttr("temperature", "${it.value}", unit)
                 break
             case("radonShortTermAvg"):
                 if(usePicoC){
-                    it.value = (it.value/37).toFloat().round(2)
+                    value = (value/37).toFloat().round(2)
                     unit="pCi/L"
                 }else
                     unit="Bq/m<sup>3</sup>"
-                if(forceInt) it.value = it.value.toFloat().toInteger()
+                if(forceInt) value = value.toFloat().toInteger()
                 break
             case("humidity"):
                 unit="%"
-                if(forceInt) it.value = it.value.toFloat().toInteger()
+                if(forceInt) value = value.toFloat().toInteger()
                 break
             case("co2"):
                 unit="ppm"
-                if(forceInt) it.value = it.value.toFloat().toInteger()
-                updateAttr("carbonDioxide", it.value, unit) //required for capability CarbonDioxideMeasurement, co2 retained for backward compatibility
+                if(forceInt) value = value.toFloat().toInteger()
+                updateAttr("carbonDioxide", value, unit) //required for capability CarbonDioxideMeasurement, co2 retained for backward compatibility
                 break
             case("pressure"):
             	if(useinHg){ //GFA
-					it.value = (it.value/33.86389).toFloat().round(3) //GFA
+					value = (value/33.86389).toFloat().round(3) //GFA
 					unit = "inHg" //GFA
 				}else //GFA
                 	unit="mBar"
-                if(forceInt) it.value = it.value.toFloat().toInteger()
+                if(forceInt) value = value.toFloat().toInteger()
                 break
             case("voc"):
                 unit="ppb"
-                if(forceInt) it.value = it.value.toFloat().toInteger()
+                if(forceInt) value = value.toFloat().toInteger()
                 break
             case("battery"):
                 unit="%"
                 break
             case("rssi"):
                 unit="dBm"
-                if(forceInt) it.value = it.value.toFloat().toInteger()
+                if(forceInt) value = value.toFloat().toInteger()
                 break
             case("mold")://mold risk index - integer 0-10
-                unit=""
-                if(forceInt) it.value = it.value.toFloat().toInteger()
+                if(forceInt) value = value.toFloat().toInteger()
                 break
-            case("relayDeviceType")://ignore
-                unit=""
+            case("relayDeviceType"):
                 break
             case("time"):// update timestamp
-                unit=null
-            	//GFA
-            	it.key = "lastPoll"
-				Date lastPoll = new Date(1000 * it.value.longValue()) // As need UNIX date which is in msec (and API value is in secs)
+            	attr = "lastPoll"
+				Date lastPoll = new Date(1000 * value.longValue()) // As need UNIX date which is in msec (and API value is in secs)
 				SimpleDateFormat sdf = new SimpleDateFormat(lstPollSdfPref ?: "yyyy-MM-dd HH:mm:ss")
-            //SimpleDateFormat sdf = new SimpleDateFormat(lstPollSdfPref)
-				it.value = sdf.format(lastPoll)
-                //state.lastUpdate = it.value.toInteger()
-            	//GFA
-                updateAttr("lastPoll", it.value, "") // unit=null above prevents generic path; call explicitly here
+				value = sdf.format(lastPoll)
+                //state.lastUpdate = value.toInteger()
                 break
             default:
-                unit=""
                 try{
-                    it.value = Math.floor(10 * it.value.toFloat()) / 10
+                    value = Math.floor(10 * value.toFloat()) / 10
                 } catch(e) {
-                    log.warn "Return Data Mismatch, Key: ${it.key} Value: ${it.value} - value will be set to zero"
-                    it.value = 0
+                    log.warn "Return Data Mismatch, Key: ${attr} Value: ${value} - value will be set to zero"
+                    value = 0
                 }
                 break
         }
-        if(debugEnabled) log.debug "${it.key}:${it.value}"
-        if((it.key != "temp" && unit != null) || it.key.startsWith('pm') || it.key == "mold") {//unit will be null for any values not tracked
-            updateAttr(it.key, it.value, unit)
-            if(debugEnabled) log.debug "${it.key}"
-            if("${it.key}" == "pm25")
-                calcPm25Aqi(it.value)
-        }
+        if(debugEnabled) log.debug "${attr}:${value}${unit}"
+        updateAttr(attr, value, unit)
+        if(attr == "pm25")
+            calcPm25Aqi(value)
     }
     calcAbsHumidity()
     if(tileTemplate && tileTemplate != "No selection" && tileTemplate != "--No Selection--"){

--- a/airthings/airthingsDevice.groovy
+++ b/airthings/airthingsDevice.groovy
@@ -145,7 +145,7 @@ def configure() {
 }
 
 void updateAttr(String aKey, aValue, String aUnit = ""){
-    desc = "${aKey} level of ${aValue} detected"
+    def desc = "${aKey} level of ${aValue} detected"
     sendEvent(name:aKey, value:aValue, unit:aUnit, descriptionText:desc)
 }
 
@@ -159,7 +159,7 @@ void dataRefresh(retData){
     if(debugEnabled) log.debug "$retData.data ${retData.data.size()}"
     retData.data.each{
         if(debugEnabled) log.debug "Each:${it.key}"
-        unit=""
+        def unit = ""
         switch (it.key){
             case("temp"):
                 unit="°C"
@@ -222,6 +222,7 @@ void dataRefresh(retData){
 				it.value = sdf.format(lastPoll)
                 //state.lastUpdate = it.value.toInteger()
             	//GFA
+                updateAttr("lastPoll", it.value, "") // unit=null above prevents generic path; call explicitly here
                 break
             default:
                 unit=""
@@ -243,7 +244,7 @@ void dataRefresh(retData){
     }
     calcAbsHumidity()
     if(tileTemplate && tileTemplate != "No selection" && tileTemplate != "--No Selection--"){
-        tileHtml = genHtml(tileTemplate)
+        def tileHtml = genHtml(tileTemplate)
         updateAttr("html","$tileHtml")
     }
 
@@ -252,6 +253,7 @@ void dataRefresh(retData){
 void calcAbsHumidity() {
     if(device.currentValue("temperature",true) == null || device.currentValue("humidity",true) == null)
         return //Calculation cannot continue
+    def deviceTempInCelsius
     if(useFahrenheit)
         deviceTempInCelsius = fahrenheitToCelsius(device.currentValue("temperature",true).toFloat())
     else
@@ -262,7 +264,7 @@ void calcAbsHumidity() {
     Double absHumidity = numerator/denominator
     //updateAttr("d", denominator)
     //updateAttr("n", numerator)
-    absHumidityR =  absHumidity.round(2)
+    def absHumidityR = absHumidity.round(2)
     updateAttr("absHumidity", absHumidityR, "g/m<sup>3</sup>")
 }
 
@@ -305,10 +307,10 @@ void calcPm25Aqi(pm25Val){
     Float aLevel = Math.floor(10 * c) / 10
     updateAttr("pm25Aqi",aLevel)
     updateAttr("airQualityIndex",aLevel.toInteger())
-    for (i=0;i<aqiLevel.size();i++){
+    for (int i=0;i<aqiLevel.size();i++){
         if(debugEnabled) log.debug "$aLevel:${aqiLevel[i].max}"
         if(aLevel <= aqiLevel[i].max){
-            pm25AqiText = "<span style='color:${aqiLevel[i].color}'>${aqiLevel[i].name}</span>"
+            def pm25AqiText = "<span style='color:${aqiLevel[i].color}'>${aqiLevel[i].name}</span>"
             updateAttr("pm25AqiText",pm25AqiText)
             break
         }


### PR DESCRIPTION
When multiple devices are available on one account, one can experience issues where changes attributed to one device spill over to another device.  For example, I would see battery events of one device show up in the event list of another.  I believe this is due to the script-level binding of some variables (i.e. not using 'def')  - in getApi in particular.  This PR fixes that issue.  

Thank you for your consideration.