### PR TITLE
Api call safety and other small fixes

### DIFF
--- a/airthings/airThingsCntrl.groovy
+++ b/airthings/airThingsCntrl.groovy
@@ -67,7 +67,6 @@ def mainPage(){
 	    	section("Main") {
 				input "debugEnabled", "bool", title:"Enable Debug Logging:", submitOnChange:true, required:false, defaultValue:false
                 if(debugEnabled) {
-                    unschedule()
                     runIn(1800,logsOff)
                 }
      	    }
@@ -236,6 +235,8 @@ def getApi(resp, data){
             }
         } else if(resp.getStatus() == 401) {
             log.error "getApi - 401 Unauthorized for ${data.cmd}, check API credentials"
+        } else {
+            log.error "getApi - unexpected response ${resp.getStatus()} for ${data.cmd}"
         }
     } catch (Exception e) {
         log.error "getApi - $e.message"        

--- a/airthings/airThingsCntrl.groovy
+++ b/airthings/airThingsCntrl.groovy
@@ -154,21 +154,27 @@ void getAuth(command){
         body: "$bodyText"
 	]
 
-    if(debugEnabled) 
+    if(debugEnabled)
         log.debug "$requestParams"
-    httpPost (requestParams) { resp ->
-        if(debugEnabled) 
-        	log.debug "${resp.properties} - ${command} - ${resp.getStatus()} "
-        if(resp.getStatus() == 200 || resp.getStatus() == 207){
-            if(resp.data){
-                    Map jsonData = (HashMap) resp.data             
-                    state.temp_token = jsonData.access_token
-                    if(debugEnabled) log.debug "Token: ${jsonData.access_token}"
-                    state.tokenExpires = (jsonData.expires_in.toLong()*1000) + new Date().getTime().toLong()
-                    SimpleDateFormat sdf= new SimpleDateFormat("HH:mm:ss yyyy-MM-dd")
-                    state.tokenExpiresDisp = sdf.format(new Date(state.tokenExpires))
-            } 
+    try {
+        httpPost (requestParams) { resp ->
+            if(debugEnabled)
+                log.debug "${resp.properties} - ${command} - ${resp.getStatus()} "
+            if(resp.getStatus() == 200 || resp.getStatus() == 207){
+                if(resp.data){
+                        Map jsonData = (HashMap) resp.data
+                        state.temp_token = jsonData.access_token
+                        if(debugEnabled) log.debug "Token: ${jsonData.access_token}"
+                        state.tokenExpires = (jsonData.expires_in.toLong()*1000) + new Date().getTime().toLong()
+                        SimpleDateFormat sdf= new SimpleDateFormat("HH:mm:ss yyyy-MM-dd")
+                        state.tokenExpiresDisp = sdf.format(new Date(state.tokenExpires))
+                }
+            } else {
+                log.error "getAuth - ${command} failed, status ${resp.getStatus()}, check API credentials"
+            }
         }
+    } catch(Exception e) {
+        log.error "getAuth - ${command} failed: ${e.message}"
     }
 }
 // End App Authorization

--- a/airthings/airThingsCntrl.groovy
+++ b/airthings/airThingsCntrl.groovy
@@ -108,7 +108,7 @@ def mainPage(){
                     else
                         state.numberDevices+=2
                 }*/
-                if (state?.numberDevices > 0){
+                if(getChildDevices().size() > 0){
                     def chdList = []
                     getChildDevices().each{
                         chdList.add("$it")
@@ -122,7 +122,7 @@ def mainPage(){
                         }
                         app.updateSetting("removeChild",[value:null,type:"enum"])
                     }
-                    
+
                 }
             }
 
@@ -218,6 +218,10 @@ def getApi(resp, data){
                     def end = data.cmd.indexOf('/',start)
                     def devId = data.cmd.substring(start,end)
                     def cd = getChildDevice("${app.id}-$devId")
+                    if(cd == null) {
+                        log.error "getApi - no child device found for id $devId, was it deleted outside the app?"
+                        return
+                    }
                     def jsonData = (HashMap) resp.json
                     cd.dataRefresh(jsonData)
                 } else {
@@ -225,7 +229,7 @@ def getApi(resp, data){
                 }
             }
         } else if(resp.getStatus() == 401) {
-            apiGet("${data.cmd}")
+            log.error "getApi - 401 Unauthorized for ${data.cmd}, check API credentials"
         }
     } catch (Exception e) {
         log.error "getApi - $e.message"        

--- a/airthings/airthingsDevice.groovy
+++ b/airthings/airthingsDevice.groovy
@@ -131,11 +131,7 @@ def updated(){
     }
     if(pollRate == null)
         device.updateSetting("pollRate",[value:0,type:"number"])
-    if(pollRate > 0){
-        runIn(pollRate*60,"refresh")
-    } else
-        unschedule("refresh")
-    refresh()
+    runIn(1, "refresh")
 }
 
 @SuppressWarnings('unused')
@@ -156,6 +152,10 @@ void refresh() {
 }
 
 void dataRefresh(retData){
+    if(retData?.data == null) {
+        log.warn "${device.displayName} - no data in response, skipping update"
+        return
+    }
     if(debugEnabled) log.debug "$retData.data ${retData.data.size()}"
     retData.data.each{
         if(debugEnabled) log.debug "Each:${it.key}"


### PR DESCRIPTION
- fix device count origin mixup in app config (hub device count not necessarily same as API returned device count)
- fix app config page not rendering when auth failed
- log unexpected API responses, not just 401 (+ wrap httpPost in try/catch)
- break auth loop when 401 returned (not recoverable with retry AFAIK)
- decouple updated() from next poll with runIn(1,...) (and simplify scheduling code)

Thank you for your consideration.
